### PR TITLE
[fix] replaced file permission attribute with '-'

### DIFF
--- a/src/main/java/de/tarent/maven/plugins/pkg/generator/SpecFileGenerator.java
+++ b/src/main/java/de/tarent/maven/plugins/pkg/generator/SpecFileGenerator.java
@@ -659,7 +659,7 @@ public class SpecFileGenerator {
 			for (AuxFile f : files) {
 				if (f.getOctalPermission() >= 0) {
 					w.print("%attr(");
-					w.print(f.getOctalPermission());
+					w.print("-");
 					w.print(",");
 					w.print(f.getOwner());
 					w.print(",");


### PR DESCRIPTION
this is necessary so that the files included in the resulting
rpm are readable and executable by everyone and writable by root
