### PR TITLE
[enhancement] introduced ignoreDependencies parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>de.tarent.maven.plugins</groupId>
     <artifactId>pkg-maven-plugin</artifactId>
-    <version>5.1.6-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven Packaging Plugin</name>

--- a/src/main/java/de/tarent/maven/plugins/pkg/TargetConfiguration.java
+++ b/src/main/java/de/tarent/maven/plugins/pkg/TargetConfiguration.java
@@ -943,7 +943,7 @@ public class TargetConfiguration {
      * should be added to the classpath line in the wrapper script.
      */
     @MergeMe(defaultBoolean = false)
-    private Boolean ignoreDependenciesInClasspath;
+    private Boolean ignoreDependencies;
 	
 	public TargetConfiguration() {
 		// Intentionally empty.
@@ -1697,12 +1697,12 @@ public class TargetConfiguration {
 		return bundleDependencyArtifacts;
 	}
 
-    public Boolean isIgnoreDependenciesInClasspath() {
-        return ignoreDependenciesInClasspath;
+    public Boolean isIgnoreDependencies() {
+        return ignoreDependencies;
     }
 
-    public void setIgnoreDependenciesInClasspath(Boolean ignoreDependenciesInClasspath) {
-        this.ignoreDependenciesInClasspath = ignoreDependenciesInClasspath;
+    public void setIgnoreDependencies(Boolean ignoreDependenciesInClasspath) {
+        this.ignoreDependencies = ignoreDependenciesInClasspath;
     }
 
 }

--- a/src/main/java/de/tarent/maven/plugins/pkg/helper/Helper.java
+++ b/src/main/java/de/tarent/maven/plugins/pkg/helper/Helper.java
@@ -1354,7 +1354,7 @@ public class Helper {
 
 		};
 
-        if (!targetConfiguration.isIgnoreDependenciesInClasspath()) {
+        if (!targetConfiguration.isIgnoreDependencies()) {
             packageMap.iterateDependencyArtifacts(l, dependencies, v, true);
         }
 
@@ -1631,7 +1631,9 @@ public class Helper {
 			}
 		};
 
-		packageMap.iterateDependencyArtifacts(l, resolvedDependencies, v, true);
+		if (!targetConfiguration.isIgnoreDependencies()) {
+		    packageMap.iterateDependencyArtifacts(l, resolvedDependencies, v, true);
+		}
 
 		return Utils
 				.joinDependencyLines(line.toString(), manualDeps.toString());


### PR DESCRIPTION
use this parameter to completely ignore maven dependencies when
determine package dependencies, classpath line generation, etc. this
replaces the former ignoreDependenciesInClasspath parameter.
