### PR TITLE
Fix aspectj entries for trusty

### DIFF
--- a/src/main/resources/de/tarent/maven/plugins/pkg/map/pm-ubuntu_trusty.xml
+++ b/src/main/resources/de/tarent/maven/plugins/pkg/map/pm-ubuntu_trusty.xml
@@ -689,7 +689,7 @@
             <entry>
                 <artifactSpec>org.aspectj:aspectjrt</artifactSpec>
                 <versionSpec>[1.6.12]</versionSpec>
-                <dependencyLine>aspectj</dependencyLine>
+                <dependencyLine>libaspectj-java</dependencyLine>
                 <jars>
                     <jar>aspectjrt.jar</jar>
                 </jars>
@@ -697,7 +697,8 @@
 
             <entry>
                 <artifactSpec>org.aspectj:aspectjweaver</artifactSpec>
-                <dependencyLine>aspectj</dependencyLine>
+                <versionSpec>[1.6.12]</versionSpec>
+                <dependencyLine>libaspectj-java</dependencyLine>
                 <jars>
                     <jar>aspectjweaver.jar</jar>
                 </jars>


### PR DESCRIPTION
The resulting package for trusty is named
libaspectj-java.

Pin the version for aspectjweaver to 1.6.12 too.